### PR TITLE
Added ability to send push notifications from backend

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,7 @@
       }
     ],
     "@typescript-eslint/no-var-requires": 0,
-    "@typescript-eslint/no-unused-vars": "warn"
+    "@typescript-eslint/no-unused-vars": "warn",
+    "@typescript-eslint/ban-ts-ignore": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5096,6 +5096,22 @@
                 }
             }
         },
+        "expo-server-sdk": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/expo-server-sdk/-/expo-server-sdk-3.6.0.tgz",
+            "integrity": "sha512-GyA0BTcFBKk/5gTEO4WOScP9hEttR+GitrcOIl7XwXwE1FHFvbluKiUc9yEjsfEYMgyd78+XhSpGVGQnutGOdA==",
+            "requires": {
+                "node-fetch": "^2.6.0",
+                "promise-limit": "^2.7.0"
+            },
+            "dependencies": {
+                "node-fetch": {
+                    "version": "2.6.1",
+                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+                    "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+                }
+            }
+        },
         "express": {
             "version": "4.17.1",
             "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -11050,6 +11066,11 @@
             "requires": {
                 "asap": "~2.0.3"
             }
+        },
+        "promise-limit": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+            "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw=="
         },
         "prompts": {
             "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "connect-mongo": "^3.2.0",
         "dotenv": "^8.2.0",
         "errorhandler": "^1.5.1",
+        "expo-server-sdk": "^3.6.0",
         "express": "^4.17.1",
         "express-flash": "0.0.2",
         "express-session": "^1.17.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import mongoose from 'mongoose';
 import passport from 'passport';
 import bluebird from 'bluebird';
 import { MONGODB_URI, SESSION_SECRET } from './util/secrets';
+import {sendBatchNotification} from './util/notifications';
 
 const MongoStore = mongo(session);
 
@@ -61,6 +62,11 @@ app.use(fileupload());
 
 // Routes
 app.post('/upload', imageController.postImage);
+app.get('/testpush', function(req, res) {
+    res.send('testing push notification');
+    // Add your ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx] to the array below to test sending push notifications to yourself
+    sendBatchNotification('Umifeeds','this is a test', ['']);
+})
 
 // Sub Routers
 import donorRouter from './routes/donors';

--- a/src/app.ts
+++ b/src/app.ts
@@ -66,7 +66,7 @@ app.get('/testpush', function(req, res) {
     res.send('testing push notification');
     // Add your ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx] to the array below to test sending push notifications to yourself
     sendBatchNotification('Umifeeds','this is a test', ['']);
-})
+});
 
 // Sub Routers
 import donorRouter from './routes/donors';

--- a/src/app.ts
+++ b/src/app.ts
@@ -62,10 +62,10 @@ app.use(fileupload());
 
 // Routes
 app.post('/upload', imageController.postImage);
-app.get('/testpush', function(req, res) {
+app.post('/testpush', function(req, res) {
     res.send('testing push notification');
-    // Add your ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx] to the array below to test sending push notifications to yourself
-    sendBatchNotification('Umifeeds','this is a test', ['']);
+    // Add your ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx] to the array below to test sending push notifications to yourself. See the frontend console for a line like Expo Push Token : ExponentPushToken[sfdjiodojifsdojisdfjio]
+    sendBatchNotification('Umi Feeds (title)', 'this is a test (body)', ['']);
 });
 
 // Sub Routers

--- a/src/util/notifications.ts
+++ b/src/util/notifications.ts
@@ -38,10 +38,8 @@ const sendPushNotifications = (messages: ExpoPushMessage[]) => {
             for (const ticket of tickets) {
                 // NOTE: Not all tickets have IDs; for example, tickets for notifications
                 // that could not be enqueued will have error information and no receipt ID.
-                // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
                 // @ts-ignore this line checks if ticket.id even exists so don't worry that it might not
                 if (ticket.id) {
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
                     // @ts-ignore already checked if ticket.id exists
                     receiptIds.push(ticket.id);
                 }
@@ -59,20 +57,17 @@ const sendPushNotifications = (messages: ExpoPushMessage[]) => {
                         // The receipts specify whether Apple or Google successfully received the
                         // notification and information about an error, if one occurred.
                         for (const receiptId in receipts) {
-                            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
                             // @ts-ignore I know this code works because it is provided by Expo
                             const { status, message, details } = receipts[receiptId];
                             if (status === 'error') {
                                 console.error(
                                     `There was an error sending a notification: ${message}`
                                 );
-                                // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
                                 // @ts-ignore I know this code works because it is provided by Expo
                                 if (details && details.error) {
                                     // The error codes are listed in the Expo documentation:
                                     // https://docs.expo.io/push-notifications/sending-notifications/#individual-errors
                                     // You must handle the errors appropriately.
-                                    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
                                     // @ts-ignore I know this code works because it is provided by Expo
                                     console.error(`The error code is ${details.error}`);
                                 }

--- a/src/util/notifications.ts
+++ b/src/util/notifications.ts
@@ -85,7 +85,7 @@ const sendPushNotifications = (messages: ExpoPushMessage[]) => {
 
 const sendBatchNotification = (title: string, body: string, expoPushTokens: ExpoPushToken[], data: object = {}) => {
     // Create the messages that you want to send to clients
-    const messages = [];
+    const messages: ExpoPushMessage[] = [];
     for (const pushToken of expoPushTokens) {
         // Each push token looks like ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]
 
@@ -102,7 +102,7 @@ const sendBatchNotification = (title: string, body: string, expoPushTokens: Expo
             body: body,
             title: title,
             data: data,
-        } as ExpoPushMessage);
+        });
     }
     sendPushNotifications(messages);
 };

--- a/src/util/notifications.ts
+++ b/src/util/notifications.ts
@@ -1,0 +1,115 @@
+import {Expo, ExpoPushMessage, ExpoPushReceiptId, ExpoPushTicket, ExpoPushToken} from 'expo-server-sdk';
+
+// Create a new Expo SDK client
+// optionally providing an access token if you have enabled push security
+
+// Currently I have not enabled push security, however this might be a good
+//    idea to look into later so 3rd parties can't send notifications to our users if they crack their tokens
+//    See this for more info: https://docs.expo.io/push-notifications/sending-notifications/#additional-security
+const expo = new Expo();
+
+const sendPushNotifications = (messages: ExpoPushMessage[]) => {
+    // The Expo push notification service accepts batches of notifications so
+    // that you don't need to send 1000 requests to send 1000 notifications. We
+    // recommend you batch your notifications to reduce the number of requests
+    // and to compress them (notifications with similar content will get
+    // compressed).
+    const chunks = expo.chunkPushNotifications(messages);
+    const tickets: ExpoPushTicket[] = [];
+    (async () => {
+        // Send the chunks to the Expo push notification service. There are
+        // different strategies you could use. A simple one is to send one chunk at a
+        // time, which nicely spreads the load out over time:
+        for (const chunk of chunks) {
+            try {
+                const ticketChunk = await expo.sendPushNotificationsAsync(chunk);
+                console.log(ticketChunk);
+                tickets.push(...ticketChunk);
+                // NOTE: If a ticket contains an error code in ticket.details.error, you
+                // must handle it appropriately. The error codes are listed in the Expo
+                // documentation:
+                // https://docs.expo.io/push-notifications/sending-notifications/#individual-errors
+            } catch (error) {
+                console.error(error);
+            }
+        }
+        setTimeout(() => {
+            const receiptIds: ExpoPushReceiptId[] = [];
+            for (const ticket of tickets) {
+                // NOTE: Not all tickets have IDs; for example, tickets for notifications
+                // that could not be enqueued will have error information and no receipt ID.
+                // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+                // @ts-ignore this line checks if ticket.id even exists so don't worry that it might not
+                if (ticket.id) {
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+                    // @ts-ignore already checked if ticket.id exists
+                    receiptIds.push(ticket.id);
+                }
+            }
+
+            const receiptIdChunks = expo.chunkPushNotificationReceiptIds(receiptIds);
+            (async () => {
+                // Like sending notifications, there are different strategies you could use
+                // to retrieve batches of receipts from the Expo service.
+                for (const chunk of receiptIdChunks) {
+                    try {
+                        const receipts = await expo.getPushNotificationReceiptsAsync(chunk);
+                        console.log(receipts);
+
+                        // The receipts specify whether Apple or Google successfully received the
+                        // notification and information about an error, if one occurred.
+                        for (const receiptId in receipts) {
+                            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+                            // @ts-ignore I know this code works because it is provided by Expo
+                            const { status, message, details } = receipts[receiptId];
+                            if (status === 'error') {
+                                console.error(
+                                    `There was an error sending a notification: ${message}`
+                                );
+                                // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+                                // @ts-ignore I know this code works because it is provided by Expo
+                                if (details && details.error) {
+                                    // The error codes are listed in the Expo documentation:
+                                    // https://docs.expo.io/push-notifications/sending-notifications/#individual-errors
+                                    // You must handle the errors appropriately.
+                                    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+                                    // @ts-ignore I know this code works because it is provided by Expo
+                                    console.error(`The error code is ${details.error}`);
+                                }
+                            }
+                        }
+                    } catch (error) {
+                        console.error(error);
+                    }
+                }
+            })();
+        }, 5000);
+    })();
+};
+
+
+const sendBatchNotification = (title: string, body: string, expoPushTokens: ExpoPushToken[], data: object = {}) => {
+    // Create the messages that you want to send to clients
+    const messages = [];
+    for (const pushToken of expoPushTokens) {
+        // Each push token looks like ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]
+
+        // Check that all your push tokens appear to be valid Expo push tokens
+        if (!Expo.isExpoPushToken(pushToken)) {
+            console.error(`Push token ${pushToken} is not a valid Expo push token`);
+            continue;
+        }
+
+        // Construct a message (see https://docs.expo.io/push-notifications/sending-notifications/)
+        messages.push({
+            to: pushToken,
+            sound: 'default',
+            body: body,
+            title: title,
+            data: data,
+        } as ExpoPushMessage);
+    }
+    sendPushNotifications(messages);
+};
+
+export {sendPushNotifications, sendBatchNotification};

--- a/src/util/notifications.ts
+++ b/src/util/notifications.ts
@@ -108,3 +108,29 @@ const sendBatchNotification = (title: string, body: string, expoPushTokens: Expo
 };
 
 export {sendPushNotifications, sendBatchNotification};
+
+/*
+This code is partially drawn from https://github.com/expo/expo-server-sdk-node, which is licensed under the MIT license.
+
+MIT License.
+
+Copyright (c) 2016-present Expo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/


### PR DESCRIPTION
Resolves https://github.com/GTBitsOfGood/umi-feeds-backend/issues/23

Creates some util functions for sending push notifications from the backend.

sendPushNotifications takes in a list of push notifications and breaks them into compressed chunks to send to the expo notifications backend.

sendBatchNotifications takes in a title, body, data, and list of expoPushTokens and sends that notification to all of the users in the list.

For now, I added a test endpoint /testpush which will send a notification to all users listed in the list in the code for that endpoint.  Later we can incorporate push notifications into other endpoints but for now, I wanted a simple way to test that the notifications work.