### PR TITLE
Donation Queue Routes

### DIFF
--- a/src/controllers/donationFormController.ts
+++ b/src/controllers/donationFormController.ts
@@ -10,7 +10,7 @@ import { userDonations } from './oldControllers/donorController';
 
 /**
  * Gets Donation Forms by User
- * @route GET /api/donationform?id={userid}[&donationFormID={formid}]
+ * @route GET /api/donationform?id={userid}&donationFormID={formid}
  */
 export const getDonationForms = (req: Request, res: Response) => {
     const userid = req.query.id || null;

--- a/src/controllers/donationFormController.ts
+++ b/src/controllers/donationFormController.ts
@@ -4,8 +4,9 @@ import { UploadedFile } from 'express-fileupload';
 import { url } from 'inspector';
 import { User, UserDocument } from '../models/User/index';
 import { deleteImageAzure, uploadImageAzure } from '../util/azure-image';
-import { OngoingDonation } from '../models/User/DonationForms';
+import { OngoingDonation, OngoingDonationDocument } from '../models/User/DonationForms';
 import { sendBatchNotification, sendPushNotifications } from '../util/notifications';
+import { userDonations } from './oldControllers/donorController';
 
 /**
  * Gets Donation Forms by User
@@ -100,7 +101,7 @@ export const postDonationForm = async (req: Request, res: Response) => {
                 // If we have a file to upload call uploadImageAzure otherwise just use the default image url
                 (req.files !== null && req.files !== undefined && req.files.image !== undefined
                     ? uploadImageAzure(req.files.image as UploadedFile) : ''),
-                User.findById(userid)
+                User.findById(userid).session(session)
             ]
         );
 
@@ -168,7 +169,7 @@ export const postDonationForm = async (req: Request, res: Response) => {
  * Updates Donation Form fields based on provided data
  * @route PUT /api/donationform?id={userid}&donationFormID={formid}
  */
-export const putDonationForm = (req: Request, res: Response) => {
+export const putDonationForm = async (req: Request, res: Response) => {
     const userid = req.query.id || null;
     const formid = req.query.donationFormID || null;
 
@@ -184,66 +185,146 @@ export const putDonationForm = (req: Request, res: Response) => {
         return;
     }
 
-    // Find user by the specified userid
-    User.findById(userid).then(async (user) => {
-        // We need to loop through and find the donation form with the matching id
-        for (const donation of user.donations) {
-            if (donation._id.toString() === formid) {
-                // req.body.data should hold the donationform information to save to the user if it is being updated
-                if (req.body !== undefined && req.body !== null && req.body.data !== undefined) {
-                    try {
-                        // Parse the JSON for the replacement values from the 'data' field of the request
-                        const replacementData = JSON.parse(req.body.data);
-                        for (const [key, value] of Object.entries(replacementData)) {
-                            if (key === 'imageLink') {
-                                continue;
-                            }
-                            // Replace all of the old values in the donationform
-                            // @ts-ignore Key is always a string, but Typescript finds that confusing
-                            donation[key] = value;
-                        }
-                    } catch (err) {
-                        res.status(400).json({ message: err.message, donationform: {} });
-                        return;
-                    }
-                }
-                let oldImageUrl:string = null;
-                // req.files.image should hold the uploaded image to forward to Azure if the image will be replaced
-                if (req.files !== undefined && req.files !== null && req.files.image !== undefined) {
-                    try {
-                        // @ts-ignore Typescript worries req.files could be an UploadedFile, but it is always an object of UploadedFiles
-                        // This await will only run once because the loop returns in this if statement
-                        // eslint-disable-next-line no-await-in-loop
-                        const newImageUrl = await uploadImageAzure(req.files.image);
+    // Checck if modified data exists in body
+    if (req.body === undefined && req.body === null && req.body.data === undefined) {
+        res.status(400).json({ message: 'No data about dish attached to key "data".', donationform: {} });
+        return;
+    }
 
-                        // Store the old image url to be deleted if everything else works.  Otherwise we don't want to
-                        //   delete it because it will still be the url for the image if the replacement doesn't happen
-                        oldImageUrl = donation.imageLink;
-                        donation.imageLink = newImageUrl;
-                    } catch (err) {
-                        res.status(400).json({ message: err.message, donationform: {} });
-                        return;
-                    }
+    // Set up transaction session
+    const session = await mongoose.startSession();
+    session.startTransaction();
+
+    try {
+        // Check if specified donation exists in Ongoing Donation queue
+        const ongoingDonation:OngoingDonationDocument = await OngoingDonation.findById(formid);
+
+        if (!ongoingDonation) {
+            throw new Error('Specified donation does not exist.');
+        }
+
+        // Check if specified User exists
+        const currentUser:UserDocument = await User.findById(userid).session(session);
+
+        if (!currentUser) {
+            throw new Error('Specified user does not exist.');
+        }
+
+        // Upload new image to Azure if necessary
+        let newImageUrl:string;
+        if (req.files !== null && req.files !== undefined && req.files.image !== undefined) {
+            newImageUrl = await uploadImageAzure(req.files.image as UploadedFile);
+        } else {
+            newImageUrl = '';
+        }
+
+        // Deletes old image from Azure if a new image is updated for donation
+        const oldImageUrl:string = ongoingDonation.imageLink;
+        if (oldImageUrl && newImageUrl) {
+            deleteImageAzure(oldImageUrl);
+        }
+
+        // Processing JSON data payload
+        const newDonationForm = JSON.parse(req.body.data);
+        newDonationForm.imageLink = newImageUrl;
+
+        // Update specified donation as a part of User's donations array
+        for (const donation of currentUser.donations) {
+            if (donation._id.toString() === formid) {
+                for (const [key, value] of Object.entries(newDonationForm)) {
+                    // Replace all of the old values in the donationform
+                    // @ts-ignore Key is always a string, but Typescript finds that confusing
+                    donation[key] = value;
                 }
-                // Save the updated donation form to the database
-                user.save().then(() => {
-                    // If we replaced the image then we have to delete the image in azure for a full cleanup
-                    if (oldImageUrl !== null) {
-                        deleteImageAzure(oldImageUrl).then(() => {
-                            res.status(200).json({ message: 'Success', donationform: donation });
-                        }).catch((err: mongoose.Error) => {
-                            res.status(400).json({ message: err.message, donationform: donation });
-                        });
-                    } else {
-                        res.status(200).json({ message: 'Success', donationform: donation });
-                    }
-                }).catch((err: mongoose.Error) => {
-                    res.status(500).json({ message: err.message, donationform: donation });
-                });
-                return;
             }
         }
-    });
+
+        // Saves updated donation to User donation array
+        const updatedDonation:UserDocument = await currentUser.save();
+        if (!updatedDonation) {
+            throw new Error('Failed to update donation for specified user');
+        }
+
+        // Update specified donation in Ongoing Donation Queue
+        const updatedOngoing = await OngoingDonation.findByIdAndUpdate(formid, newDonationForm, { new: true }).session(session);
+        if (!updatedOngoing) {
+            throw new Error('Failed to update Ongoing Donation for specified user.');
+        }
+
+        await session.commitTransaction();
+        res.status(200).json({
+            message: 'Success',
+            donationform: updatedOngoing
+        });
+        /*
+        // Find user by the specified userid
+        User.findById(userid).then(async (user) => {
+            // We need to loop through and find the donation form with the matching id
+            for (const donation of user.donations) {
+                if (donation._id.toString() === formid) {
+                    // req.body.data should hold the donationform information to save to the user if it is being updated
+                    if (req.body !== undefined && req.body !== null && req.body.data !== undefined) {
+                        try {
+                            // Parse the JSON for the replacement values from the 'data' field of the request
+                            const replacementData = JSON.parse(req.body.data);
+                            for (const [key, value] of Object.entries(replacementData)) {
+                                if (key === 'imageLink') {
+                                    continue;
+                                }
+                                // Replace all of the old values in the donationform
+                                // @ts-ignore Key is always a string, but Typescript finds that confusing
+                                donation[key] = value;
+                            }
+                        } catch (err) {
+                            res.status(400).json({ message: err.message, donationform: {} });
+                            return;
+                        }
+                    }
+                    let oldImageUrl:string = null;
+                    // req.files.image should hold the uploaded image to forward to Azure if the image will be replaced
+                    if (req.files !== undefined && req.files !== null && req.files.image !== undefined) {
+                        try {
+                            // @ts-ignore Typescript worries req.files could be an UploadedFile, but it is always an object of UploadedFiles
+                            // This await will only run once because the loop returns in this if statement
+                            // eslint-disable-next-line no-await-in-loop
+                            const newImageUrl = await uploadImageAzure(req.files.image);
+
+                            // Store the old image url to be deleted if everything else works.  Otherwise we don't want to
+                            //   delete it because it will still be the url for the image if the replacement doesn't happen
+                            oldImageUrl = donation.imageLink;
+                            donation.imageLink = newImageUrl;
+                        } catch (err) {
+                            res.status(400).json({ message: err.message, donationform: {} });
+                            return;
+                        }
+                    }
+                    // Save the updated donation form to the database
+                    user.save().then(() => {
+                        // If we replaced the image then we have to delete the image in azure for a full cleanup
+                        if (oldImageUrl !== null) {
+                            deleteImageAzure(oldImageUrl).then(() => {
+                                res.status(200).json({ message: 'Success', donationform: donation });
+                            }).catch((err: mongoose.Error) => {
+                                res.status(400).json({ message: err.message, donationform: donation });
+                            });
+                        } else {
+                            res.status(200).json({ message: 'Success', donationform: donation });
+                        }
+                    }).catch((err: mongoose.Error) => {
+                        res.status(500).json({ message: err.message, donationform: donation });
+                    });
+                    return;
+                }
+            }
+        })  */
+    } catch (err) {
+        await session.abortTransaction();
+        res.status(500).json({
+            message: err.message
+        });
+    } finally {
+        session.endSession();
+    }
 };
 
 /**

--- a/src/controllers/donationFormController.ts
+++ b/src/controllers/donationFormController.ts
@@ -144,6 +144,7 @@ export const postDonationForm = async (req: Request, res: Response) => {
 
         // Adds donation to OngoingDonations queue
         newDonationForm.userID = userid;
+
         const savedOngoing = await OngoingDonation.create([newDonationForm], { session });
 
         if (!savedOngoing) {
@@ -228,7 +229,7 @@ export const putDonationForm = async (req: Request, res: Response) => {
         }
 
         // Update specified donation as a part of User's donations array
-        let oldImageUrl:string = '';
+        let oldImageUrl = '';
         for (const donation of currentUser.donations) {
             if (donation._id.toString() === formid) {
                 oldImageUrl = donation.imageLink;

--- a/src/controllers/donationFormController.ts
+++ b/src/controllers/donationFormController.ts
@@ -143,6 +143,7 @@ export const postDonationForm = async (req: Request, res: Response) => {
         });
 
         // Adds donation to OngoingDonations queue
+        newDonationForm.userID = userid;
         const savedOngoing = await OngoingDonation.create([newDonationForm], { session });
 
         if (!savedOngoing) {
@@ -196,15 +197,21 @@ export const putDonationForm = async (req: Request, res: Response) => {
     session.startTransaction();
 
     try {
-        // Check if specified donation exists in Ongoing Donation queue
-        const ongoingDonation:OngoingDonationDocument = await OngoingDonation.findById(formid);
+        // Check if specified donation and specified User exists
+        const [ongoingDonation, currentUser] = await Promise.all(
+            [
+                OngoingDonation.findById(formid),
+                User.findById(userid).session(session)
+            ]
+        );
+        //const ongoingDonation:OngoingDonationDocument = await OngoingDonation.findById(formid);
 
         if (!ongoingDonation) {
             throw new Error('Specified donation does not exist.');
         }
 
         // Check if specified User exists
-        const currentUser:UserDocument = await User.findById(userid).session(session);
+        //const currentUser:UserDocument = await User.findById(userid).session(session);
 
         if (!currentUser) {
             throw new Error('Specified user does not exist.');

--- a/src/controllers/ongoingDonationsController.ts
+++ b/src/controllers/ongoingDonationsController.ts
@@ -1,5 +1,7 @@
+import mongoose from 'mongoose';
 import { Response, Request } from 'express';
 import { UploadedFile } from 'express-fileupload';
+import { User, UserDocument } from '../models/User/index';
 import { OngoingDonation, OngoingDonationDocument } from '../models/User/DonationForms';
 import { uploadImageAzure, deleteImageAzure } from '../util/azure-image';
 
@@ -79,7 +81,7 @@ export const updateOngoingDonation = (req: Request, res: Response) => {
  * @route DELETE /api/ongoingdonations/:donationID
  *
  */
-export const deleteOngoingDonation = (req: Request, res: Response) => {
+export const deleteOngoingDonation =  async (req: Request, res: Response) => {
     const donationId = req.params.donationID;
 
     if (!donationId) {
@@ -87,15 +89,56 @@ export const deleteOngoingDonation = (req: Request, res: Response) => {
         return;
     }
 
-    OngoingDonation.deleteOne({ _id: donationId })
-        .then((result) => {
-            if (result.deletedCount === 1) {
-                res.status(200).json({ message: 'Success' });
-            } else {
-                res.status(404).json({ message: 'The specified ongoing donation does not exist.' });
-            }
-        })
-        .catch((error: Error) => {
-            res.status(400).json({ message: error.message });
+    // Set up transaction session
+    const session = await mongoose.startSession();
+    session.startTransaction();
+
+    try {
+        // Get userId to modify status in User's donation array
+        const ongoingDonation:OngoingDonationDocument = await OngoingDonation.findById(donationId);
+        if (!ongoingDonation) {
+            throw new Error('Specified donation does not exist');
+        }
+        const userId = ongoingDonation.userID;
+
+        // Delete specified ongoing donation from queue
+        const deletedQueueResponse = await OngoingDonation.deleteOne({ _id: donationId }).session(session);
+        if (deletedQueueResponse.deletedCount !== 1) {
+            throw new Error('Could not delete donation from Ongoing Donation Queue.');
+        }
+
+        // Update status and ongoing of specified donation in User's donation array
+        const updatedDonationResponse:mongoose.UpdateWriteOpResult = await User.updateOne({ _id: userId, 'donations._id': donationId }, { $set: { 'donations.$.status': 'completed', 'donations.$.ongoing': false  } }).session(session);
+
+        if (updatedDonationResponse.nModified  !== 1) {
+            throw new Error('Could not update donation status for User.');
+        }
+
+        /*
+        OngoingDonation.deleteOne({ _id: donationId })
+            .then((result) => {
+                if (result.deletedCount === 1) {
+                    res.status(200).json({ message: 'Success' });
+                } else {
+                    res.status(404).json({ message: 'The specified ongoing donation does not exist.' });
+                }
+            })
+            .catch((error: Error) => {
+                res.status(400).json({ message: error.message });
+            }); */
+
+        // Commit transaction after deleting donation from queue and marking it as complete in array
+        await session.commitTransaction();
+        res.status(200).json({
+            message: 'Success',
+            donationForm: ongoingDonation
         });
+    } catch (err) {
+        await session.abortTransaction();
+        res.status(500).json({
+            message: err.message
+        });
+    } finally {
+        session.endSession();
+    }
 };

--- a/src/controllers/ongoingDonationsController.ts
+++ b/src/controllers/ongoingDonationsController.ts
@@ -19,6 +19,7 @@ export const getOngoingDonations = (req: Request, res: Response) => {
 /**
  * Updating corresponding ongoing donation
  * @route PUT /api/ongoingdonations/:donationID
+ * @param {string} req.body.json Stringfied json with updated donation information
  *
  */
 export const updateOngoingDonation = async (req: Request, res: Response) => {
@@ -141,6 +142,7 @@ export const deleteOngoingDonation = async (req: Request, res: Response) => {
             throw new Error('Specified donation does not exist');
         }
         const userId = ongoingDonation.userID;
+        const imageUrl:string = ongoingDonation.imageLink;
 
         // Delete specified ongoing donation from queue
         const deletedQueueResponse = await OngoingDonation.deleteOne({ _id: donationId }).session(session);
@@ -153,6 +155,12 @@ export const deleteOngoingDonation = async (req: Request, res: Response) => {
 
         if (updatedDonationResponse.nModified !== 1) {
             throw new Error('Could not update donation status for User.');
+        }
+
+        // Deletes image from Azure if transactions are successful
+        const deletedResponse = await deleteImageAzure(imageUrl);
+        if (!deletedResponse) {
+            throw new Error('Could not delete donation image from Azure.');
         }
 
         // Commit transaction after deleting donation from queue and marking it as complete in array

--- a/src/models/User/DonationForms.ts
+++ b/src/models/User/DonationForms.ts
@@ -49,7 +49,6 @@ export type OngoingDonationDocument = mongoose.Document & {
   _id?: string; // the unqiue id assigned to a donation form. Let Mongo create this when you insert a document without any _id attribute
   ongoing: boolean;
   status: string;
-  imageLink: string;
   dishes: DonationDishes[];
   pickupAddress: Address;
   pickupInstructions: string;
@@ -68,7 +67,6 @@ export const OngoingDonationsSchema = new mongoose.Schema<OngoingDonationDocumen
         type: String,
         enum: ['pending pickup', 'picked up', 'dropped off'],
     },
-    imageLink: { type: String, default: '' },
     dishes: { type: [DonationDishesSchema], required: true },
     pickupAddress: { type: AddressSchema, required: true },
     pickupInstructions: { type: String, required: true },

--- a/src/models/User/DonationForms.ts
+++ b/src/models/User/DonationForms.ts
@@ -59,6 +59,7 @@ export type OngoingDonationDocument = mongoose.Document & {
   lockedByVolunteer: boolean; // whether the donation has been locked by a volunteer
   confirmPickUpTime: Date; // time when donation has been picked up by volunteer
   confirmDropOffTime: Date; // time when donation has been dropped off by volunteer
+  userID: string;
 }
 
 export const OngoingDonationsSchema = new mongoose.Schema<OngoingDonationDocument>({
@@ -76,6 +77,7 @@ export const OngoingDonationsSchema = new mongoose.Schema<OngoingDonationDocumen
     lockedByVolunteer: { type: Boolean, required: true },
     confirmPickUpTime: { type: Date, required: true },
     volunteerLockTime: { type: Date, required: true },
+    userID: { type: String, required: true}
 }, { timestamps: true });
 
 export const OngoingDonation = mongoose.model<OngoingDonationDocument>('ongoingdonations', OngoingDonationsSchema);

--- a/src/models/User/DonationForms.ts
+++ b/src/models/User/DonationForms.ts
@@ -77,7 +77,7 @@ export const OngoingDonationsSchema = new mongoose.Schema<OngoingDonationDocumen
     lockedByVolunteer: { type: Boolean, required: true },
     confirmPickUpTime: { type: Date, required: true },
     volunteerLockTime: { type: Date, required: true },
-    userID: { type: String, required: true}
+    userID: { type: String, required: true }
 }, { timestamps: true });
 
 export const OngoingDonation = mongoose.model<OngoingDonationDocument>('ongoingdonations', OngoingDonationsSchema);

--- a/src/models/User/DonationForms.ts
+++ b/src/models/User/DonationForms.ts
@@ -32,10 +32,10 @@ export const DonationFormSchema = new mongoose.Schema<DonationForm>({
     ongoing: { type: Boolean, required: true },
     status: {
         type: String,
-        enum: ['pending pickup', 'picked up', 'dropped off'],
+        enum: ['pending pickup', 'picked up', 'dropped off', 'Rejected'],
     },
     imageLink: { type: String, required: false },
-    dishes: { type: [DonationDishesSchema], required: true },
+    donationDishes: { type: [DonationDishesSchema], required: true },
     pickupAddress: { type: AddressSchema, required: true },
     pickupInstructions: { type: String, default: 'None' },
     pickupStartTime: { type: Date, required: true },
@@ -61,11 +61,12 @@ export type OngoingDonationDocument = mongoose.Document & {
   userID: string;
 }
 
-export const OngoingDonationsSchema = new mongoose.Schema<OngoingDonationDocument>({
+const OngoingDonationsSchema = new mongoose.Schema<OngoingDonationDocument>({
+    userID: { type: String, required: true },
     ongoing: { type: Boolean, required: true, default: true },
     status: {
         type: String,
-        enum: ['pending pickup', 'picked up', 'dropped off'],
+        enum: ['pending pickup', 'picked up', 'dropped off', 'Rejected'],
     },
     dishes: { type: [DonationDishesSchema], required: true },
     pickupAddress: { type: AddressSchema, required: true },
@@ -75,7 +76,6 @@ export const OngoingDonationsSchema = new mongoose.Schema<OngoingDonationDocumen
     lockedByVolunteer: { type: Boolean, required: true },
     confirmPickUpTime: { type: Date, required: true },
     volunteerLockTime: { type: Date, required: true },
-    userID: { type: String, required: true }
 }, { timestamps: true });
 
 export const OngoingDonation = mongoose.model<OngoingDonationDocument>('ongoingdonations', OngoingDonationsSchema);


### PR DESCRIPTION
##  Donation Queue Routes

Adds transactions for updating and deleting User's donation forms and ongoing donations.

### How to Test

Use postman collection:
https://www.getpostman.com/collections/b73fd5aef04469071b5c

### Important Changes

- Branched off #97 
- Adds `userID` to OngoingDonation schema
- Refactors `PUT /api/donationform?id={userid}&donationFormID={formid}` using async/await and transactions
-  Modifies `PUT /api/ongoingdonations/:donationID` and `DELETE /api/ongoingdonations/:donationID` to use transactions 
- Check slack for more detailed comments

### Related Github Issues

- GTBitsOfGood/umi-feeds-app#134

### Related PRs

- #97 

### Checklist

- [x]  Database schema docs have been updated or are not necessary
- [x]  Code follows design and style guidelines
- [x]  Code is commented with doc blocks
- [x]  Tests have been written and executed or are not necessary
- [x]  Latest code has been rebased from base branch (usually `develop`)
- [x]  Commits follow guidelines (concise, squashed, etc)
- [x]  Github issues have been linked in relevant commits
- [x]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR
