### PR TITLE
Donation History Search for Past Donations within 30 days or in a specified month

### DIFF
--- a/src/controllers/searchController.ts
+++ b/src/controllers/searchController.ts
@@ -1,0 +1,122 @@
+import { Response, Request } from 'express';
+import { User } from '../models/User/index';
+import { OngoingDonationDocument } from '../models/User/DonationForms';
+/* eslint quote-props: ["error", "consistent"] */
+
+/**
+ * Gets Donation Forms within the past 30 days
+ * @route GET /api/search/donations/last30days
+ *
+ * */
+export const last30DaysDonationsHistory = (req: Request, res: Response) => {
+    const numDays = 30;
+    return User.aggregate([
+        {
+            '$match': {
+                'donations': {
+                    '$exists': true
+                }
+            }
+        }, {
+            '$project': {
+                '_id': 0,
+                'donations': 1
+            }
+        }, {
+            '$unwind': {
+                'path': '$donations',
+                'preserveNullAndEmptyArrays': false
+            }
+        }, {
+            '$match': {
+                'donations.status': 'Delivered'
+            }
+        }, {
+            // Check if donation's drop off time was within 30 days of the current day
+            // by converting to milliseconds, subtracting from 30 days ago in ms and comparing
+            '$match': {
+                'donations.confirmDropOffTime': {
+                    '$gt': new Date(new Date().getTime() - (1000 * 60 * 60 * 24 * numDays))
+                }
+            }
+        }
+    ]).then((result) => {
+        if (result) {
+            // Format Mongoose aggregation output to array of DonationDocuments
+            const formattedResult:OngoingDonationDocument[] = [];
+            for (let i = 0; i < result.length; i++) {
+                formattedResult.push(result[i].donations);
+            }
+            res.status(200).json({ 'donations': formattedResult });
+        } else {
+            res.status(400).json({ 'donations': [] });
+        }
+    }).catch((error: Error) => {
+        res.status(400).json({ message: error.message });
+    });
+};
+
+/*
+* Gets past Donations forms in the specified month
+* GET /api/search/donations/:month/:year
+*
+*/
+export const monthDonationsHistory = (req: Request, res: Response) => {
+    const month:number = +req.params.month;
+    const year:number = +req.params.year;
+
+    return User.aggregate([
+        {
+            '$match': {
+                'donations': {
+                    '$exists': true
+                }
+            }
+        }, {
+            '$unwind': {
+                'path': '$donations',
+                'preserveNullAndEmptyArrays': false
+            }
+        }, {
+            // Break down confirmDropOffTime to Month and Year and store for comparison
+            '$project': {
+                '_id': 0,
+                'donations': 1,
+                'year': {
+                    '$year': '$donations.confirmDropOffTime'
+                },
+                'month': {
+                    '$month': '$donations.confirmDropOffTime'
+                }
+            }
+        }, {
+            '$match': {
+                'donations.status': 'Delivered'
+            }
+        }, {
+            '$match': {
+                'year': year,
+                'month': month
+            }
+        }, {
+            // Remove month and year fields from aggregated documents
+            '$project': {
+                '_id': 0,
+                'donations': 1
+            }
+        }
+    ]).then((result) => {
+        if (result) {
+            // Format Mongoose aggregation output to array of DonationDocuments
+            const formattedResult:OngoingDonationDocument[] = [];
+            for (let i = 0; i < result.length; i++) {
+                formattedResult.push(result[i].donations);
+            }
+            res.status(200).json({ 'donations': formattedResult });
+        } else {
+            res.status(400).json({ 'donations': [] });
+        }
+    }).catch((error: Error) => {
+        res.status(400).json({ message: error.message });
+    });
+};

--- a/src/controllers/searchController.ts
+++ b/src/controllers/searchController.ts
@@ -49,7 +49,7 @@ export const last30DaysDonationsHistory = (req: Request, res: Response) => {
             }
             res.status(200).json({ 'donations': formattedResult });
         } else {
-            res.status(400).json({ 'donations': [] });
+            res.status(200).json({ 'donations': [] });
         }
     }).catch((error: Error) => {
         res.status(400).json({ message: error.message });
@@ -114,7 +114,7 @@ export const monthDonationsHistory = (req: Request, res: Response) => {
             }
             res.status(200).json({ 'donations': formattedResult });
         } else {
-            res.status(400).json({ 'donations': [] });
+            res.status(200).json({ 'donations': [] });
         }
     }).catch((error: Error) => {
         res.status(400).json({ message: error.message });

--- a/src/controllers/searchController.ts
+++ b/src/controllers/searchController.ts
@@ -1,13 +1,13 @@
 import { Response, Request } from 'express';
 import { User } from '../models/User/index';
-import { OngoingDonationDocument } from '../models/User/DonationForms';
+import { DonationForm } from '../models/User/DonationForms';
 /* eslint quote-props: ["error", "consistent"] */
 
 /**
  * Gets Donation Forms within the past 30 days
  * @route GET /api/search/donations/last30days
  *
- * */
+ */
 export const last30DaysDonationsHistory = (req: Request, res: Response) => {
     const numDays = 30;
     return User.aggregate([
@@ -42,8 +42,8 @@ export const last30DaysDonationsHistory = (req: Request, res: Response) => {
         }
     ]).then((result) => {
         if (result) {
-            // Format Mongoose aggregation output to array of DonationDocuments
-            const formattedResult:OngoingDonationDocument[] = [];
+            // Format Mongoose aggregation output to array of DonationForms
+            const formattedResult:DonationForm[] = [];
             for (let i = 0; i < result.length; i++) {
                 formattedResult.push(result[i].donations);
             }
@@ -56,9 +56,9 @@ export const last30DaysDonationsHistory = (req: Request, res: Response) => {
     });
 };
 
-/*
+/**
 * Gets past Donations forms in the specified month
-* GET /api/search/donations/:month/:year
+* @route GET /api/search/donations/:month/:year
 *
 */
 export const monthDonationsHistory = (req: Request, res: Response) => {
@@ -107,8 +107,8 @@ export const monthDonationsHistory = (req: Request, res: Response) => {
         }
     ]).then((result) => {
         if (result) {
-            // Format Mongoose aggregation output to array of DonationDocuments
-            const formattedResult:OngoingDonationDocument[] = [];
+            // Format Mongoose aggregation output to array of DonationForms
+            const formattedResult:DonationForm[] = [];
             for (let i = 0; i < result.length; i++) {
                 formattedResult.push(result[i].donations);
             }

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -4,6 +4,7 @@ import DishRoutes from './dishes';
 import DonationFormRoutes from './donations';
 import OngoingDonationRoutes from './ongoingDonations';
 import userRoute from './user';
+import SearchRoutes from './search';
 
 const router = express.Router();
 
@@ -14,5 +15,7 @@ router.use('/dishes', DishRoutes);
 router.use('/donationform', DonationFormRoutes);
 
 router.use('/ongoingdonations', OngoingDonationRoutes);
+
+router.use('/search', SearchRoutes);
 
 export default router;

--- a/src/routes/api/search.ts
+++ b/src/routes/api/search.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+import * as searchController from '../../controllers/searchController';
+
+const router = express.Router();
+/*
+* Code routes here for search
+*/
+router.get('/donations/last30days', searchController.last30DaysDonationsHistory);
+router.get('/donations/:month/:year', searchController.monthDonationsHistory);
+
+export default router;


### PR DESCRIPTION
## Past Donation History Search

This PR implements past donations history search functionality using MongoDB aggregations. It adds a new search controller to handle GET routes `/api/search/donations/last30days` and `/api/search/donations/:month/:year`. Donations are considered past if their status is 'Delivered'. 

### How to Test

Use this [Postman collection](https://www.getpostman.com/collections/11980a1f0811de5f7098).
For `donations/:month/:year`, you can try `1/2021`, `1/2022`, and `2/2022`. (Input here are numbers)

### Related Github Issues

- GTBitsOfGood/umi-feeds-app#143

### Checklist

- [x]  Database schema docs have been updated or are not necessary
- [x]  Code follows design and style guidelines
- [x]  Code is commented with doc blocks
- [x]  Tests have been written and executed or are not necessary
- [x]  Latest code has been rebased from base branch (usually `develop`)
- [x]  Commits follow guidelines (concise, squashed, etc)
- [x]  Github issues have been linked in relevant commits
- [x]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR
