### PR TITLE
Updated GET /ongoingdonations 

### DIFF
--- a/src/controllers/donationFormController.ts
+++ b/src/controllers/donationFormController.ts
@@ -74,7 +74,7 @@ export const getOngoingDonationForms = (req: Request, res: Response) => {
  * @route POST /api/donationform?id={userid}
  */
 export const postDonationForm = async (req: Request, res: Response) => {
-    const userid = req.query.id || null;
+    const userid = req.query.id as string || null;
 
     // We need a userid because all donation forms are stored under the user documents
     if (userid == null) {
@@ -111,6 +111,11 @@ export const postDonationForm = async (req: Request, res: Response) => {
         const newDonationForm = JSON.parse(req.body.data);
         newDonationForm.imageLink = url;
 
+        // Modify Dish IDs to ObjectID
+        for (let i = 0; i < newDonationForm.donationDishes.length; i++) {
+            newDonationForm.donationDishes[i].dishID = mongoose.Types.ObjectId(newDonationForm.donationDishes[i].dishID);
+        }
+
         // Adding new donation to specified user
         currentUser.donations.push(newDonationForm);
         const savedDonation = await currentUser.save()
@@ -141,7 +146,7 @@ export const postDonationForm = async (req: Request, res: Response) => {
         });
 
         // Adds donation to OngoingDonations queue
-        newDonationForm.userID = userid;
+        newDonationForm.userID = mongoose.Types.ObjectId(userid);
 
         const savedOngoing = await OngoingDonation.create([newDonationForm], { session });
 
@@ -225,6 +230,11 @@ export const putDonationForm = async (req: Request, res: Response) => {
         const newDonationForm = JSON.parse(req.body.data);
         if (newImageUrl) {
             newDonationForm.imageLink = newImageUrl;
+        }
+
+        // Modify dishIDs to ObjectID
+        for (let i = 0; i < newDonationForm.donationDishes.length; i++) {
+            newDonationForm.donationDishes[i].dishID = mongoose.Types.ObjectId(newDonationForm.donationDishes[i].dishID);
         }
 
         // Update specified donation as a part of User's donations array

--- a/src/controllers/ongoingDonationsController.ts
+++ b/src/controllers/ongoingDonationsController.ts
@@ -6,13 +6,16 @@ import { sendBatchNotification } from '../util/notifications';
 /* eslint quote-props: ["error", "consistent"] */
 /**
  * Gets all ongoing donations
+ * Uses MongoDB aggregations and lookup to get detailed dishes information
+ * based on User's dishes and ongoingDonation's donationDishes
+ *
  * @route GET /api/ongoingdonations
  *
  */
 export const getOngoingDonations = (req: Request, res: Response) => {
     return OngoingDonation.aggregate([
         {
-            // Perforrm Join on matching user id
+            // Perform join on matching user id
             '$lookup': {
                 'from': 'users',
                 'localField': 'userID',
@@ -47,7 +50,7 @@ export const getOngoingDonations = (req: Request, res: Response) => {
                 'joinedUser': 0
             }
         }, {
-            // Unwind donationDishess and dishes
+            // Unwind donationDishes and dishes
             '$unwind': {
                 'path': '$donationDishes',
                 'preserveNullAndEmptyArrays': false

--- a/src/controllers/ongoingDonationsController.ts
+++ b/src/controllers/ongoingDonationsController.ts
@@ -12,6 +12,7 @@ import { sendBatchNotification } from '../util/notifications';
 export const getOngoingDonations = (req: Request, res: Response) => {
     return OngoingDonation.aggregate([
         {
+            // Perforrm Join on matching user id
             '$lookup': {
                 'from': 'users',
                 'localField': 'userID',
@@ -19,12 +20,14 @@ export const getOngoingDonations = (req: Request, res: Response) => {
                 'as': 'joinedUser'
             }
         }, {
+            // Add new joined fields
             '$addFields': {
                 'dishes': '$joinedUser.dishes',
                 'name': '$joinedUser.name',
                 'phoneNumber': '$joinedUser.phoneNumber'
             }
         }, {
+            // New fields are default arrays so unwinded to objects and values
             '$unwind': {
                 'path': '$dishes',
                 'preserveNullAndEmptyArrays': false
@@ -44,6 +47,7 @@ export const getOngoingDonations = (req: Request, res: Response) => {
                 'joinedUser': 0
             }
         }, {
+            // Unwind donationDishess and dishes
             '$unwind': {
                 'path': '$donationDishes',
                 'preserveNullAndEmptyArrays': false
@@ -54,6 +58,7 @@ export const getOngoingDonations = (req: Request, res: Response) => {
                 'preserveNullAndEmptyArrays': false
             }
         }, {
+            // Matched donation dishes and User's dishes
             '$match': {
                 '$expr': {
                     '$eq': [
@@ -62,6 +67,7 @@ export const getOngoingDonations = (req: Request, res: Response) => {
                 }
             }
         }, {
+            // "Join" dishes
             '$addFields': {
                 'mergedDishes': {
                     '$mergeObjects': [
@@ -75,6 +81,7 @@ export const getOngoingDonations = (req: Request, res: Response) => {
                 'dishes': 0
             }
         }, {
+            // Rewind unwindings
             '$group': {
                 '_id': '$_id',
                 'donationDishes': {
@@ -109,6 +116,18 @@ export const getOngoingDonations = (req: Request, res: Response) => {
                 },
                 'pickupEndTime': {
                     '$first': '$pickupEndTime'
+                },
+                'confirmPickUpTime': {
+                    '$first': '$confirmPickUpTime'
+                },
+                'confirmDropOffTime': {
+                    '$first': '$confirmDropOffTime'
+                },
+                'volunteerLockTime': {
+                    '$first': '$volunteerLockTime'
+                },
+                'lockedByVolunteer': {
+                    '$first': '$lockedByVolunteer'
                 },
                 'userID': {
                     '$first': '$userID'

--- a/src/models/User/DonationForms.ts
+++ b/src/models/User/DonationForms.ts
@@ -24,7 +24,7 @@ export type DonationForm = {
 }
 
 export const DonationDishesSchema = new mongoose.Schema<DonationDishes>({
-    dishID: { type: String, required: true },
+    dishID: { type: mongoose.Schema.Types.ObjectId, required: true },
     quantity: { type: Number, required: true },
 });
 
@@ -67,7 +67,7 @@ export type OngoingDonationDocument = mongoose.Document & {
 
 // Status will be a ENUM once the status are actually set
 const OngoingDonationsSchema = new mongoose.Schema<OngoingDonationDocument>({
-    userID: { type: String, required: true },
+    userID: { type: mongoose.Schema.Types.ObjectId, required: true },
     businessName: { type: String, required: true },
     ongoing: { type: Boolean, required: true, default: true },
     status: {


### PR DESCRIPTION
## Join Users and ongoingDonations for relevant dish information

Updates `GET /ongoingdonations` to get all ongoing donations from OngoingDonation collection queue and uses MongoDB's `lookup` aggregation to join Users and OngoingDonations collection to provide relevant dish information. 

### How to Test

Call `/api/ongoingdonations`

### Important Changes
- Modifies `DonationDishes` schema and `OngoingDonations` schema for the fields: `dishID` and `userID` respectively to ObjectId instead of string to work with the MongoDB join aggregation
- Convert `dishID` and `userID` to ObjectId logic added to `POST` and `PUT` for DonationForm and OngoingDonation instead of passing them to database as strings.

### Related Github Issues

- GTBitsOfGood/umi-feeds-app#155

### Checklist

- [x]  Database schema docs have been updated or are not necessary
- [x]  Code follows design and style guidelines
- [x]  Code is commented with doc blocks
- [x]  Tests have been written and executed or are not necessary
- [x]  Latest code has been rebased from base branch (usually `develop`)
- [x]  Commits follow guidelines (concise, squashed, etc)
- [x]  Github issues have been linked in relevant commits
- [x]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR